### PR TITLE
Avoid creating the native string buffer for every search

### DIFF
--- a/spec/onig-scanner-spec.js
+++ b/spec/onig-scanner-spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const OnigScanner = require('..').OnigScanner
+const OnigString = require('..').OnigString
 
 describe('OnigScanner', () => {
   describe('::findNextMatchSync', () => {
@@ -12,6 +13,20 @@ describe('OnigScanner', () => {
       expect(scanner.findNextMatchSync('xxaxxbxxc', 7).index).toBe(2)
       expect(scanner.findNextMatchSync('xxaxxbxxc', 9)).toBe(null)
     })
+    
+    it('works with onig string', () => {
+      let scanner = new OnigScanner(['Wh', 'e'])
+      let onigString = new OnigString('WhereWhileWhen');
+      try {
+        expect(scanner.findNextMatchSync(onigString, 0).captureIndices).toEqual([{index: 0, start: 0, end: 2, length: 2}])
+        expect(scanner.findNextMatchSync(onigString, 2).captureIndices).toEqual([{index: 0, start: 2, end: 3, length: 1}])
+        expect(scanner.findNextMatchSync(onigString, 3).captureIndices).toEqual([{index: 0, start: 4, end: 5, length: 1}])
+        expect(scanner.findNextMatchSync(onigString, 5).captureIndices).toEqual([{index: 0, start: 5, end: 7, length: 2}])
+        expect(scanner.findNextMatchSync(onigString, 7).captureIndices).toEqual([{index: 0, start: 9, end: 10, length: 1}])
+      } finally {
+        onigString.dispose();
+      }
+    })    
 
     it('includes the scanner with the results', () => {
       let scanner = new OnigScanner(['a'])

--- a/spec/onig-string-spec.js
+++ b/spec/onig-string-spec.js
@@ -1,30 +1,54 @@
 'use strict'
 
 const OnigString = require('..').OnigString
+const OnigScanner = require('..').OnigScanner
 
 describe('OnigString', () => {
   it('has a length property', () => {
-    expect(new OnigString('abc').length).toBe(3)
+    withOnigString('abc', onigString => { 
+      expect(onigString.length).toBe(3)
+    })  
   })
 
   it('can be converted back into a string', () => {
-    expect(new OnigString('abc').toString()).toBe('abc')
+    withOnigString('abc', onigString => { 
+      expect(onigString.toString()).toBe('abc')
+    })
   })
 
   it('can retrieve substrings (for conveniently inspecting captured text)', () => {
     const string = 'abcdef'
-    const onigString = new OnigString(string)
-    expect(onigString.substring(2, 3)).toBe(string.substring(2, 3))
-    expect(onigString.substring(2)).toBe(string.substring(2))
-    expect(onigString.substring()).toBe(string.substring())
-    expect(onigString.substring(-1)).toBe(string.substring(-1))
-    expect(onigString.substring(-1, -2)).toBe(string.substring(-1, -2))
+    withOnigString(string, onigString => {
+      expect(onigString.substring(2, 3)).toBe(string.substring(2, 3))
+      expect(onigString.substring(2)).toBe(string.substring(2))
+      expect(onigString.substring()).toBe(string.substring())
+      expect(onigString.substring(-1)).toBe(string.substring(-1))
+      expect(onigString.substring(-1, -2)).toBe(string.substring(-1, -2))
 
-    onigString.substring({})
-    onigString.substring(null, undefined)
+      onigString.substring({})
+      onigString.substring(null, undefined)
+    })
   })
 
   it('handles invalid arguments', () => {
     expect(() => new OnigString(undefined)).toThrow('Argument must be a string')
   })
+
+  it('keeps and releases pointer', () => {
+    let onigString = new OnigString('abs');
+    expect(onigString.hasPtr()).toBe(false);
+    new OnigScanner(['a']).findNextMatchSync(onigString, 0);
+    expect(onigString.hasPtr()).toBe(true);
+    onigString.dispose();
+    expect(onigString.hasPtr()).toBe(false);
+  })  
 })
+
+function withOnigString(string, closure) {
+  const onigString = new OnigString(string);
+  try {
+    closure(onigString);
+  } finally {
+    onigString.dispose();
+  }
+}

--- a/src/OnigScanner.ts
+++ b/src/OnigScanner.ts
@@ -102,6 +102,7 @@ export class OnigScanner {
     public findNextMatchSync(string: string | OnigString, startPosition: number): IOnigMatch {
         if (startPosition == null) { startPosition = 0 }
         let onigStr = this.convertToOnigString(string)
+        if (!onigStr) return null;
         startPosition = this.convertToNumber(startPosition)
 
         let onigNativeInfo = cache.get(this)
@@ -186,10 +187,9 @@ export class OnigScanner {
     }
 
     public convertToOnigString(value: string | OnigString) : OnigString {
-        if (typeof value === 'string') {
-            return new OnigString(value)
-        }
-        return value
+        if (value instanceof OnigString) return value
+        if (typeof value === 'string') { return new OnigString(value) }
+        return null;
     }
 
     public convertToString(value) {

--- a/src/OnigScanner.ts
+++ b/src/OnigScanner.ts
@@ -101,7 +101,7 @@ export class OnigScanner {
      */
     public findNextMatchSync(string: string | OnigString, startPosition: number): IOnigMatch {
         if (startPosition == null) { startPosition = 0 }
-        string = this.convertToString(string)
+        let onigStr = this.convertToOnigString(string)
         startPosition = this.convertToNumber(startPosition)
 
         let onigNativeInfo = cache.get(this)
@@ -126,9 +126,7 @@ export class OnigScanner {
         }
 
         const resultInfoReceiverPtr = onigasmH._malloc(8)
-        const u8Encoded = encode(string as string)
-        const strPtr = onigasmH._malloc(u8Encoded.length)
-        onigasmH.HEAPU8.set(u8Encoded, strPtr)
+        const strPtr = onigStr.toAsmString()
         // const strSize = onigasmH.lengthBytesUTF8(string) + 1
         // const strPtr = onigasmH._malloc(strSize)
         // const bytesWritten = onigasmH.stringToUTF8(string, strPtr, strSize)
@@ -156,7 +154,9 @@ export class OnigScanner {
             encodedResultLength,
         ] = new Uint32Array(onigasmH.buffer, resultInfoReceiverPtr, 3)
 
-        onigasmH._free(strPtr)
+        if (onigStr !== string) {
+            onigStr.dispose()
+        }
         onigasmH._free(resultInfoReceiverPtr)
         if (encodedResultLength > 0) {
             const encodedResult = new Uint32Array(onigasmH.buffer, encodedResultBeginAddress, encodedResultLength)
@@ -185,12 +185,19 @@ export class OnigScanner {
         return null
     }
 
+    public convertToOnigString(value: string | OnigString) : OnigString {
+        if (typeof value === 'string') {
+            return new OnigString(value)
+        }
+        return value
+    }
+
     public convertToString(value) {
         if (value === undefined) return 'undefined'
         if (value === null) return 'null'
         if (value instanceof OnigString) return value.content
         return value.toString()
-    }
+    } 
 
     public convertToNumber(value) {
         value = parseInt(value)

--- a/src/OnigString.ts
+++ b/src/OnigString.ts
@@ -37,6 +37,11 @@ class OnigString {
         return this.ptr;
     }
 
+    /** For testing purposes */
+    public hasPtr() {
+        return !!this.ptr;
+    }
+
     public dispose(): void {
         if (this.ptr) {
             onigasmH._free(this.ptr);

--- a/src/OnigString.ts
+++ b/src/OnigString.ts
@@ -1,5 +1,9 @@
+import { onigasmH } from "./onigasmH";
+import { encode } from "./UTF8Encoder";
+
 class OnigString {
-    private source: string
+    private source: string;
+    private ptr: number;
 
     constructor(content: string) {
         if (typeof content !== 'string') {
@@ -22,6 +26,22 @@ class OnigString {
 
     public toString = (start, end) => {
         return this.source
+    }
+
+    public toAsmString(): number {
+        if (!this.ptr) {
+            const u8Encoded = encode(this.source);
+            this.ptr = onigasmH._malloc(u8Encoded.length);
+            onigasmH.HEAPU8.set(u8Encoded, this.ptr);
+        }
+        return this.ptr;
+    }
+
+    public dispose(): void {
+        if (this.ptr) {
+            onigasmH._free(this.ptr);
+            this.ptr = null;
+        }
     }
 
 }


### PR DESCRIPTION
Avoid the creation of the native string buffer (and the encoding)

- Store the native string buffer in the OnigString
- Add a 'dispose' to OnigString (breaking change: clients must adopt)