### PR TITLE
Encode string once and reuse for subsequent calls

### DIFF
--- a/src/OnigString.ts
+++ b/src/OnigString.ts
@@ -1,11 +1,19 @@
+import { encode } from "./UTF8Encoder";
+
 class OnigString {
     private source: string
+    private _utf8Bytes: Uint8Array
 
     constructor(content: string) {
         if (typeof content !== 'string') {
             throw new TypeError('Argument must be a string')
         }
         this.source = content
+        this._utf8Bytes = encode(content)
+    }
+
+    public get utf8Bytes(): Uint8Array {
+        return this._utf8Bytes
     }
 
     public get content(): string {


### PR DESCRIPTION
For times when apps use same string multiple times with `findNextMatch` etc, it is very expensive to run UTF8 encoding over and over.

For such cases, it is now advised to create an instance of `OnigString` and keep it referenced. Then, pass that `OnigString` ref to `findNextMatch` instead of literal strings for better performance.

Following code was run against `onigasm@2.0` (before) and current patch (after):

```javascript
import {
    loadWASM,
    OnigScanner,
    OnigString
} from 'onigasm'


(async () => {
    await loadWASM(require(`onigasm/lib/onigasm.wasm`))

    const str = await (await fetch('node_modules/typescript/lib/typescriptServices.js')).text()

    const onigStr0 = new OnigString(str.repeat(3))
    const onigStr1 = new OnigString(str.repeat(4))

    const scanner = new OnigScanner(['searchTillTheEndButYouWontFindMe'])

    const t0 = performance.now()    
    const m0_1 = scanner.findNextMatchSync(onigStr0)
    const m1_1 = scanner.findNextMatchSync(onigStr1)
    const m0_2 = scanner.findNextMatchSync(onigStr0)
    const m1_2 = scanner.findNextMatchSync(onigStr1)
    const m0_3 = scanner.findNextMatchSync(onigStr0)
    const m1_3 = scanner.findNextMatchSync(onigStr1)

    console.log('Took ', performance.now() - t0, 'ms')
})()
```

### Before (onigasm@2.0)
![](https://i.imgur.com/DrUY69r.png)
___
### After (current patch)
![](https://i.imgur.com/o7OoGBR.png)