### PR TITLE
More mapping table improvements

### DIFF
--- a/spec/onig-string-spec.js
+++ b/spec/onig-string-spec.js
@@ -39,6 +39,65 @@ describe('OnigString', () => {
     expect(string.convertUtf8OffsetToUtf16(1)).toEqual(1);
     expect(string.convertUtf8OffsetToUtf16(2)).toEqual(1);
     expect(string.convertUtf8OffsetToUtf16(3)).toEqual(2);
-    expect(string.convertUtf8OffsetToUtf16(4)).toEqual(3);   
+    expect(string.convertUtf8OffsetToUtf16(4)).toEqual(3);
   })
+
+  it('mapping 2/3/4 byte UTF-8 encoding', () => {
+    let string = new OnigString('123$¢€𐍈123');
+    expect(Array.from(string.utf8Bytes)).toEqual(
+      [0x31 /*1*/, 0x32 /*2*/, 0x33 /*3*/, 0x24 /*$*/, 0xc2 /*¢*/, 0xa2, 0xe2 /*€*/, 0x82, 0xac, 0xf0 /*𐍈*/, 0x90, 0x8d, 0x88, 0x31 /*1*/, 0x32 /*2*/, 0x33 /*3*/, 0x00]
+    );
+    expect(string.convertUtf16OffsetToUtf8(0)).toEqual(0);
+    expect(string.convertUtf16OffsetToUtf8(1)).toEqual(1);
+    expect(string.convertUtf16OffsetToUtf8(2)).toEqual(2);
+    expect(string.convertUtf16OffsetToUtf8(3)).toEqual(3);
+    expect(string.convertUtf16OffsetToUtf8(4)).toEqual(4);
+    expect(string.convertUtf16OffsetToUtf8(5)).toEqual(6);
+    expect(string.convertUtf16OffsetToUtf8(6)).toEqual(9);
+    expect(string.convertUtf16OffsetToUtf8(7)).toEqual(9);
+    expect(string.convertUtf16OffsetToUtf8(8)).toEqual(13);
+    expect(string.convertUtf16OffsetToUtf8(9)).toEqual(14);
+    expect(string.convertUtf16OffsetToUtf8(10)).toEqual(15);    
+
+    expect(string.convertUtf8OffsetToUtf16(0)).toEqual(0);
+    expect(string.convertUtf8OffsetToUtf16(1)).toEqual(1);
+    expect(string.convertUtf8OffsetToUtf16(2)).toEqual(2);
+    expect(string.convertUtf8OffsetToUtf16(3)).toEqual(3);
+    expect(string.convertUtf8OffsetToUtf16(4)).toEqual(4);
+    expect(string.convertUtf8OffsetToUtf16(5)).toEqual(4);
+    expect(string.convertUtf8OffsetToUtf16(6)).toEqual(5);
+    expect(string.convertUtf8OffsetToUtf16(7)).toEqual(5);
+    expect(string.convertUtf8OffsetToUtf16(8)).toEqual(5);
+    expect(string.convertUtf8OffsetToUtf16(9)).toEqual(6);
+    expect(string.convertUtf8OffsetToUtf16(10)).toEqual(6);
+    expect(string.convertUtf8OffsetToUtf16(11)).toEqual(6);
+    expect(string.convertUtf8OffsetToUtf16(12)).toEqual(6);
+    expect(string.convertUtf8OffsetToUtf16(13)).toEqual(8);
+    expect(string.convertUtf8OffsetToUtf16(14)).toEqual(9);
+    expect(string.convertUtf8OffsetToUtf16(15)).toEqual(10);
+  })
+
+  it('mapping UTF-16 surrogate pairs ', () => {
+    let string = new OnigString('1𩸽𩹀');
+    expect(Array.from(string.utf8Bytes)).toEqual(
+      [0x31, 0xf0, 0xa9, 0xb8, 0xbd, 0xf0, 0xa9, 0xb9, 0x80, 0x0]
+    );
+    expect(string.convertUtf16OffsetToUtf8(0)).toEqual(0);
+    expect(string.convertUtf16OffsetToUtf8(1)).toEqual(1);
+    expect(string.convertUtf16OffsetToUtf8(2)).toEqual(1);
+    expect(string.convertUtf16OffsetToUtf8(3)).toEqual(5); 
+    expect(string.convertUtf16OffsetToUtf8(4)).toEqual(5);
+
+    expect(string.convertUtf8OffsetToUtf16(0)).toEqual(0);
+    expect(string.convertUtf8OffsetToUtf16(1)).toEqual(1);
+    expect(string.convertUtf8OffsetToUtf16(2)).toEqual(1);
+    expect(string.convertUtf8OffsetToUtf16(3)).toEqual(1);
+    expect(string.convertUtf8OffsetToUtf16(4)).toEqual(1);
+    expect(string.convertUtf8OffsetToUtf16(5)).toEqual(3);
+    expect(string.convertUtf8OffsetToUtf16(6)).toEqual(3);
+    expect(string.convertUtf8OffsetToUtf16(7)).toEqual(3);
+    expect(string.convertUtf8OffsetToUtf16(8)).toEqual(3);    
+    
+  }) 
+
 })


### PR DESCRIPTION
Here are more performance improvements around utf-8 mapping:

- based on how large the urf-8 indexes can be (maximum is utf-16.length * 3), create a UInt8/ 16/ 32 Array 
- create the mapping table starting from the offset of the first multi byte character, and normalize the urf-8 indexes by that index
   - `_mappingTableStartOffset`: utf16-offset where the mapping table starts. Before that index: utf16-index === utf8-index
   - `_utf8Indexes`: utf-16 to utf-8 mapping table for all uft-8 indexes starting at `_mappingTableStartOffset`. utf8-index are always starting at 0.
   - Example: _mappingTableStartOffset === 10, _utf8Indexes = [0, 3, 6] 
-> utf8 index at 10 = 10, utf8 index at 11 = 13