### PR TITLE
Test for #17

### DIFF
--- a/spec/test-scan.js
+++ b/spec/test-scan.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const OnigString = require('..').OnigString
+const OnigScanner = require('..').OnigScanner
+
+describe('Scanner', () => {
+    it('does not throw on PHP regexp from issue #17', () => {
+        const scanner = new OnigScanner(["(?i)^\\s*(trait)\\s+([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)"]);
+        const res = scanner.findNextMatchSync(new OnigString("trait test {\n"), 0);
+        expect(res.captureIndices[1].start).toBe(0)
+    })
+});


### PR DESCRIPTION
The test fails against onigasm@2.2.2, but works against master built against emscripten 1.39.2.

I used emscripten 1.39.2 from https://github.com/emscripten-core/emsdk, following the instructions [here](https://emscripten.org/docs/getting_started/downloads.html.

I verified that all vscode-textmate tests pass as well.

@NeekSandhu Can you compile and publish an updated version?
(or make me a npm contributor (npm user id: aeschli))