### PR TITLE
Export isInitialized from onigasmH

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { loadWASM } from './onigasmH'
+import { isInitialized, loadWASM } from './onigasmH'
 import OnigRegExp, { IOnigSearchResult } from './OnigRegExp'
 import OnigScanner, { IOnigCaptureIndex } from './OnigScanner'
 import OnigString from './OnigString'
 
-export { loadWASM, OnigScanner, OnigRegExp, OnigString, IOnigCaptureIndex, IOnigSearchResult }
+export { isInitialized, loadWASM, OnigScanner, OnigRegExp, OnigString, IOnigCaptureIndex, IOnigSearchResult }

--- a/src/onigasmH.ts
+++ b/src/onigasmH.ts
@@ -42,7 +42,7 @@ async function initModule(bytes: ArrayBuffer) {
     })
 }
 
-let isInitialized = false
+export let isInitialized = false
 
 /**
  * Mount the .wasm file that will act as library's "backend"


### PR DESCRIPTION
It would be useful to export `isInitialized` from `onigasmH` so that we can call `loadWASM` based on whether it has already been initialized.